### PR TITLE
Marshal the ticket to bytes instead of storing it in the session struct

### DIFF
--- a/v8/client/TGSExchange.go
+++ b/v8/client/TGSExchange.go
@@ -51,7 +51,7 @@ func (cl *Client) TGSExchange(tgsReq messages.TGSReq, kdcRealm string, tgt messa
 		}
 		// Server referral https://tools.ietf.org/html/rfc6806.html#section-8
 		// The TGS Rep contains a TGT for another domain as the service resides in that domain.
-		cl.addSession(tgsRep.TicketBytes, tgsRep.Ticket, tgsRep.DecryptedEncPart)
+		cl.addSession(tgsRep.Ticket, tgsRep.DecryptedEncPart)
 		realm := tgsRep.Ticket.SName.NameString[len(tgsRep.Ticket.SName.NameString)-1]
 		referral++
 		if types.IsFlagSet(&tgsReq.ReqBody.KDCOptions, flags.EncTktInSkey) && len(tgsReq.ReqBody.AdditionalTickets) > 0 {

--- a/v8/client/session.go
+++ b/v8/client/session.go
@@ -68,7 +68,6 @@ type session struct {
 	renewTill            time.Time
 	flags                asn1.BitString
 	tgt                  messages.Ticket
-	ticketBytes          []byte
 	sessionKey           types.EncryptionKey
 	sessionKeyExpiration time.Time
 	cancel               chan bool
@@ -86,7 +85,7 @@ type jsonSession struct {
 
 // AddSession adds a session for a realm with a TGT to the client's session cache.
 // A goroutine is started to automatically renew the TGT before expiry.
-func (cl *Client) addSession(ticketBytes []byte, tgt messages.Ticket, dep messages.EncKDCRepPart) {
+func (cl *Client) addSession(tgt messages.Ticket, dep messages.EncKDCRepPart) {
 	if strings.ToLower(tgt.SName.NameString[0]) != "krbtgt" {
 		// Not a TGT
 		return
@@ -99,7 +98,6 @@ func (cl *Client) addSession(ticketBytes []byte, tgt messages.Ticket, dep messag
 		endTime:              dep.EndTime,
 		renewTill:            dep.RenewTill,
 		tgt:                  tgt,
-		ticketBytes:          ticketBytes,
 		flags:                dep.Flags,
 		sessionKey:           dep.Key,
 		sessionKeyExpiration: dep.KeyExpiration,

--- a/v8/messages/KDCRep.go
+++ b/v8/messages/KDCRep.go
@@ -40,7 +40,6 @@ type KDCRepFields struct {
 	CRealm           string
 	CName            types.PrincipalName
 	Ticket           Ticket
-	TicketBytes      []byte
 	EncPart          types.EncryptedData
 	DecryptedEncPart EncKDCRepPart
 }
@@ -94,14 +93,13 @@ func (k *ASRep) Unmarshal(b []byte) error {
 		return krberror.Errorf(err, krberror.EncodingError, "error unmarshaling Ticket within AS_REP")
 	}
 	k.KDCRepFields = KDCRepFields{
-		PVNO:        m.PVNO,
-		MsgType:     m.MsgType,
-		PAData:      m.PAData,
-		CRealm:      m.CRealm,
-		CName:       m.CName,
-		Ticket:      tkt,
-		TicketBytes: m.Ticket.Bytes,
-		EncPart:     m.EncPart,
+		PVNO:    m.PVNO,
+		MsgType: m.MsgType,
+		PAData:  m.PAData,
+		CRealm:  m.CRealm,
+		CName:   m.CName,
+		Ticket:  tkt,
+		EncPart: m.EncPart,
 	}
 	return nil
 }
@@ -150,14 +148,13 @@ func (k *TGSRep) Unmarshal(b []byte) error {
 		return krberror.Errorf(err, krberror.EncodingError, "error unmarshaling Ticket within TGS_REP")
 	}
 	k.KDCRepFields = KDCRepFields{
-		PVNO:        m.PVNO,
-		MsgType:     m.MsgType,
-		PAData:      m.PAData,
-		CRealm:      m.CRealm,
-		CName:       m.CName,
-		Ticket:      tkt,
-		TicketBytes: m.Ticket.Bytes,
-		EncPart:     m.EncPart,
+		PVNO:    m.PVNO,
+		MsgType: m.MsgType,
+		PAData:  m.PAData,
+		CRealm:  m.CRealm,
+		CName:   m.CName,
+		Ticket:  tkt,
+		EncPart: m.EncPart,
 	}
 	return nil
 }


### PR DESCRIPTION
Passing the ticket bytes around and adding them to the session struct is unnecessary as we can just marshal the ticket back to bytes 